### PR TITLE
Add encodeURIComponent for chinese

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -2,6 +2,7 @@ module.exports = {
   // 服务端端口，需要与disqus-proxy前端设置一致
   port: 5509,
 
+  api_key: 'your api key',
   // 你的diqus secret key
   api_secret: 'your secret key',
 

--- a/server/index.js
+++ b/server/index.js
@@ -9,13 +9,14 @@ const cors = require('kcors')
 const config = require('./config')
 // const config = require('./my-config')
 
-
-if (config.log === 'file') log4js.configure({
-  appenders: [{
-    type: 'file',
-    filename: 'disqus-proxy.log'
-  }]
-})
+if (config.log === 'file') {
+  log4js.configure({
+    appenders: [{
+      type: 'file',
+      filename: 'disqus-proxy.log'
+    }]
+  })
+}
 
 app.use(bodyParser())
 app.use(cors())
@@ -29,7 +30,7 @@ if (socks5 && typeof socks5.host === 'string' && typeof socks5.port === 'number'
     agentOptions: {
       socksHost: socks5.host,
       socksPort: socks5.port
-    },
+    }
   }
 }
 
@@ -43,7 +44,9 @@ router.get('/api/getThreads', async function (ctx) {
       url: 'https://disqus.com/api/3.0/threads/list.json?' +
       'api_secret=' + config.api_secret +
       '&forum=' + config.username +
-      '&thread:ident=' + ctx.request.query.identifier,
+      // '&thread:ident=' + ctx.request.query.identifier,
+      // 此处如果不对identifier encode, 如果identifier中含有中文，disqus api会不识别报错
+      '&thread:ident=' + encodeURIComponent(ctx.request.query.identifier),
       json: true
     }))
   } catch (e) {
@@ -55,7 +58,6 @@ router.get('/api/getThreads', async function (ctx) {
   ctx.body = result
 })
 
-
 router.get('/api/getComments', async function (ctx) {
   logger.info('Get Comments with identifier: ' + ctx.request.query.identifier)
   let result
@@ -66,7 +68,9 @@ router.get('/api/getComments', async function (ctx) {
       url: 'https://disqus.com/api/3.0/threads/listPosts.json?' +
       'api_secret=' + config.api_secret +
       '&forum=' + config.username +
-      '&thread:ident=' + ctx.request.query.identifier,
+      // '&thread:ident=' + ctx.request.query.identifier,
+      // 此处如果不对identifier encode, 如果identifier中含有中文，disqus api会不识别报错
+      '&thread:ident=' + encodeURIComponent(ctx.request.query.identifier),
       json: true
     }))
   } catch (e) {
@@ -86,7 +90,7 @@ router.post('/api/createComment', async function (ctx) {
       url: 'https://disqus.com/api/3.0/posts/create.json',
       method: 'POST',
       form: Object.assign(ctx.request.body, {
-        api_key: 'E8Uh5l5fHZ6gD8U3KycjAIAk46f68Zw7C6eW8WSjZvCLXebZ7p0r1yrYDrLilk2F',
+        api_key: config.api_key
       }),
       json: true
     }))


### PR DESCRIPTION
nodejs接口服务中对参数 `identifier` 进行了 `encodeURIComponent` 处理，不然disqus 的接口会报错，如果 `identifier` 参数中含有中文字符。