### PR TITLE
添加username选项

### DIFF
--- a/src/components/CommentList.jsx
+++ b/src/components/CommentList.jsx
@@ -15,7 +15,7 @@ export default class CommentList extends Component {
     const commentLists = topLevelComments.map(comment => ({
       comment,
       author: comment.author.name,
-      isPrimary: comment.author.username === window.disqusProxy.shortname,
+      isPrimary: comment.author.username === window.disqusProxy.username,
       children: getChildren(+comment.id)
     }))
 
@@ -26,7 +26,7 @@ export default class CommentList extends Component {
         if (comment.parent === id) list.unshift({
           comment,
           author: comment.author.name,
-          isPrimary: comment.author.username === window.disqusProxy.shortname,
+          isPrimary: comment.author.username === window.disqusProxy.username,
           children: getChildren(+comment.id)
         })
       }


### PR DESCRIPTION
不是所有的网站的shortname都和username相同的，所以需要添加username选项：

```
disqus_proxy:
  shortname: ciqu
  username: ciqu
  host: disqus-proxy.ycwalker.com
  port: 443
  admin_avatar: /avatars/admin-avatar.jpg
  default_avatar: /avatars/default-avatar.png
```