### PR TITLE
Simple fix for #21 and some code improvement

### DIFF
--- a/lib/template_locals.js
+++ b/lib/template_locals.js
@@ -1,9 +1,9 @@
 module.exports = function (hexo) {
   return function (locals) {
 
-    if (!locals.page || locals.page.__index) return locals;
+    if (!locals.page || locals.page.__index) return locals
 
-    const config = hexo.config.disqus_proxy;
+    const config = hexo.config.disqus_proxy
 
     const script = `
       <script>
@@ -19,9 +19,9 @@ module.exports = function (hexo) {
           this.page.url = window.location.href;
           this.page.identifier = window.disqusProxy.identifier;
         };
-      </script>`;
-    locals.page.content = locals.page.content ? locals.page.content : '' + script;
+      </script>`
+    locals.page.content = locals.page.content ? locals.page.content : '' + script
 
-    return locals;
-   };
-};
+    return locals
+   }
+}

--- a/lib/template_locals.js
+++ b/lib/template_locals.js
@@ -20,7 +20,7 @@ module.exports = function (hexo) {
           this.page.identifier = window.disqusProxy.identifier;
         };
       </script>`
-    locals.page.content = locals.page.content ? locals.page.content : '' + script
+    if (locals.page.content) locals.page.content = locals.page.content + script
 
     return locals
    }

--- a/lib/template_locals.js
+++ b/lib/template_locals.js
@@ -1,9 +1,9 @@
 module.exports = function (hexo) {
   return function (locals) {
 
-    if (!locals.page) return locals
+    if (!locals.page || locals.page.__index) return locals;
 
-    const config = hexo.config.disqus_proxy
+    const config = hexo.config.disqus_proxy;
 
     const script = `
       <script>
@@ -19,9 +19,9 @@ module.exports = function (hexo) {
           this.page.url = window.location.href;
           this.page.identifier = window.disqusProxy.identifier;
         };
-      </script>`
-    locals.page.content = locals.page.content + script
+      </script>`;
+    locals.page.content = locals.page.content + script;
 
-    return locals
-  }
-}
+    return locals;
+   };
+};

--- a/lib/template_locals.js
+++ b/lib/template_locals.js
@@ -20,6 +20,8 @@ module.exports = function (hexo) {
           this.page.identifier = window.disqusProxy.identifier;
         };
       </script>`
+
+    // Avoid the value undefined being casted into the string "undefined"
     if (locals.page.content) locals.page.content = locals.page.content + script
 
     return locals

--- a/lib/template_locals.js
+++ b/lib/template_locals.js
@@ -22,7 +22,7 @@ module.exports = function (hexo) {
       </script>`
 
     // Avoid the value undefined being casted into the string "undefined"
-    if (locals.page.content) locals.page.content = locals.page.content + script
+    if (locals.page.content != null) locals.page.content = locals.page.content + script
 
     return locals
    }

--- a/lib/template_locals.js
+++ b/lib/template_locals.js
@@ -20,7 +20,7 @@ module.exports = function (hexo) {
           this.page.identifier = window.disqusProxy.identifier;
         };
       </script>`;
-    locals.page.content = locals.page.content + script;
+    locals.page.content = locals.page.content ? locals.page.content : '' + script;
 
     return locals;
    };


### PR DESCRIPTION
Hey, here's a simple repair, but still doesn't fix the problem regarding posts with little characters. I came into realizing that the problem is more likely to happen on the index page. Therefore, I added: 
`if (!locals.page || locals.page.__index) return locals`.

Also, I improved:
`locals.page.content = locals.page.content ? locals.page.content : '' + script;`
to avoid "undefined" being parsed into the string.

Thx.

  